### PR TITLE
don't display wms layer when canton is inactive

### DIFF
--- a/src/components/MapComponent.vue
+++ b/src/components/MapComponent.vue
@@ -173,6 +173,13 @@ watch(
       return
     }
 
+    // Do not display WMS layers when disabled in configuration
+    if (config && !config.active) {
+      wmsLayers.value = []
+      legendAvailable.value = false
+      return
+    }
+
     wmsLayers.value = config.layers.map((layer) => ({
       key: layer.name,
       source: new TileWMS({

--- a/src/types/wms.ts
+++ b/src/types/wms.ts
@@ -17,10 +17,14 @@ export interface Layer {
 }
 
 export interface CantonWmsConfig {
+  active: boolean
   name: string
   wms_url: string
-  info_format: string
-  layers: Layer[]
-  legend_url?: string
+  query_url: string
   thematic_geoportal_url?: string
+  legend_url?: string
+  info_format: string
+  bbox_delta: number
+  style?: string
+  layers: Layer[]
 }


### PR DESCRIPTION
While it's useful to say that information could not be retrieved and show where to find further information, we don't want to display layers that are not OK