### PR TITLE
feat: give backend url in workflow

### DIFF
--- a/.github/workflows/release_and_push_s3.yml
+++ b/.github/workflows/release_and_push_s3.yml
@@ -37,7 +37,8 @@ jobs:
 
       # Build the app
       - name: Build drill-frontend
-        run: npm run build
+        run: |
+          VITE_BACKEND_URL=${{vars.SFOE_PROMETHEON_CLOUDFRONT_BACKEND_URL_DEV }} npm run build
 
       # Archive build output into a zip file
       - name: Create zip archive


### PR DESCRIPTION
to keep the cloudfront URL secured, push it with the workflow env. (in principle access is also blocked by WAF)